### PR TITLE
Feature: Add Skeleton and Bounding Box Overlay to Browser Extension

### DIFF
--- a/browser-extension/chrome-extension/src/content.js
+++ b/browser-extension/chrome-extension/src/content.js
@@ -3,12 +3,10 @@ import { getVideo, disconnectOverlayObserver, removeOverlayCanvas, createOverlay
 
 const PANEL_ID = 'yt-shot-labeler-panel';
 let detector = null;
-let overlayActive = false;
 let poseLoopId = null;
 
 // Main pose overlay loop
 async function poseOverlayLoop(video, overlay) {
-  if (!overlayActive) return;
   const currentVideo = getVideo();
   let currentOverlay = overlay;
   if (currentVideo !== video) {
@@ -37,13 +35,11 @@ async function startPoseOverlay() {
   }
   if (!detector) detector = await setupDetector();
   const overlay = createOverlayCanvas(video);
-  overlayActive = true;
   poseOverlayLoop(video, overlay);
 }
 
 // Stop overlay
 function stopPoseOverlay() {
-  overlayActive = false;
   if (poseLoopId) {
     cancelAnimationFrame(poseLoopId);
     poseLoopId = null;

--- a/browser-extension/chrome-extension/src/content.js
+++ b/browser-extension/chrome-extension/src/content.js
@@ -5,25 +5,15 @@ const PANEL_ID = 'yt-shot-labeler-panel';
 let detector = null;
 let poseLoopId = null;
 
-// Main pose overlay loop
+// Pose overlay loop
 async function poseOverlayLoop(video, overlay) {
-  const currentVideo = getVideo();
-  let currentOverlay = overlay;
-  if (currentVideo !== video) {
-    removeOverlayCanvas();
-    disconnectOverlayObserver();
-    const initialWidth = currentVideo.videoWidth;
-    const initialHeight = currentVideo.videoHeight;
-    currentOverlay = createOverlayCanvas(currentVideo);
-    video = currentVideo;
-  }
   if (video.videoWidth === 0 || video.videoHeight === 0 || video.paused || video.ended) {
-    poseLoopId = requestAnimationFrame(() => poseOverlayLoop(video, currentOverlay));
+    poseLoopId = requestAnimationFrame(() => poseOverlayLoop(video, overlay));
     return;
   }
   const poses = await detector.estimatePoses(video, { maxPoses: 6 });
-  drawKeypoints(currentOverlay, poses);
-  poseLoopId = requestAnimationFrame(() => poseOverlayLoop(video, currentOverlay));
+  drawKeypoints(overlay, poses);
+  poseLoopId = requestAnimationFrame(() => poseOverlayLoop(video, overlay));
 }
 
 // Start overlay

--- a/browser-extension/chrome-extension/src/content.js
+++ b/browser-extension/chrome-extension/src/content.js
@@ -1,6 +1,3 @@
-window.addEventListener('DOMContentLoaded', init); // Ensures that init runs only after HTML document is fully loaded and parsed
-document.addEventListener('yt-navigate-finish', init); // Ensures that init re-runs after navigating to new videos
-
 import { createLabelerPanel } from './panel.js'; 
 import { getVideo, disconnectOverlayObserver, removeOverlayCanvas, createOverlayCanvas, drawKeypoints, setupDetector } from './utils.js'; 
 
@@ -11,9 +8,14 @@ let poseLoopId = null;
 
 // Initialize main video and overlay state
 export function init() {
-  if (overlayActive) stopPoseOverlay();
-  // Optionally, auto-start overlay here if desired
+  if (overlayActive) {
+    stopPoseOverlay(); // stop overlay if active
+    startPoseOverlay(); // andre-start overlay
+  }
 }
+
+window.addEventListener('DOMContentLoaded', init); // Ensures that init runs only after HTML document is fully loaded and parsed
+document.addEventListener('yt-navigate-finish', init); // Ensures that init re-runs after navigating to new videos
 
 // Main pose overlay loop
 async function poseOverlayLoop(video, overlay) {
@@ -45,7 +47,6 @@ async function poseOverlayLoop(video, overlay) {
 
 // Start overlay
 async function startPoseOverlay() {
-  if (overlayActive) return;
   const video = getVideo();
   if (!video || video.videoWidth === 0) {
     alert('No video element found or video not loaded.');

--- a/browser-extension/chrome-extension/src/content.js
+++ b/browser-extension/chrome-extension/src/content.js
@@ -1,5 +1,6 @@
 import { togglePanel } from './panel.js';
-import { getVideo, disconnectOverlayObserver, removeOverlayCanvas, createOverlayCanvas, drawKeypoints, setupDetector } from './utils.js'; 
+import { getVideo, disconnectOverlayObserver, removeOverlayCanvas, createOverlayCanvas, setupDetector } from './utils.js'; 
+import { drawKeypoints, drawSkeletonAndBoxes} from './poseDrawing.js'; 
 
 let detector = null; // Pose detector instance (needed for pose estimation)
 let poseLoopId = null; // ID of the pose overlay loop (needed for canceling)
@@ -7,7 +8,12 @@ let poseLoopId = null; // ID of the pose overlay loop (needed for canceling)
 // Pose overlay loop
 async function poseOverlayLoop(video, detector, overlay) {
   const poses = await detector.estimatePoses(video, { maxPoses: 6 });
+  // draw keypoints
   drawKeypoints(overlay, poses);
+  // draw skeleton
+  const ctx = overlay.getContext('2d');
+  drawSkeletonAndBoxes(ctx, poses);
+  // request next animation frame
   poseLoopId = window.requestAnimationFrame(() => poseOverlayLoop(video, detector, overlay));
 }
 

--- a/browser-extension/chrome-extension/src/content.js
+++ b/browser-extension/chrome-extension/src/content.js
@@ -27,12 +27,6 @@ async function poseOverlayLoop(video, overlay) {
     disconnectOverlayObserver();
     const initialWidth = currentVideo.videoWidth;
     const initialHeight = currentVideo.videoHeight;
-    let tries = 0;
-    while (tries < 40) {
-      await new Promise(res => setTimeout(res, 50));
-      if (currentVideo.videoWidth !== initialWidth || currentVideo.videoHeight !== initialHeight) break;
-      tries++;
-    }
     currentOverlay = createOverlayCanvas(currentVideo);
     video = currentVideo;
   }

--- a/browser-extension/chrome-extension/src/content.js
+++ b/browser-extension/chrome-extension/src/content.js
@@ -1,7 +1,6 @@
-import { createLabelerPanel } from './panel.js'; 
+import { togglePanel } from './panel.js';
 import { getVideo, disconnectOverlayObserver, removeOverlayCanvas, createOverlayCanvas, drawKeypoints, setupDetector } from './utils.js'; 
 
-const PANEL_ID = 'yt-shot-labeler-panel';
 let detector = null;
 
 // Pose overlay loop
@@ -39,10 +38,8 @@ window.addEventListener('pose-overlay-control', (e) => {
 });
 
 // Panel toggle logic
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((msg) => {
   if (msg.action === 'toggle-panel') {
-    const panel = document.getElementById(PANEL_ID);
-    if (panel) panel.remove();
-    else createLabelerPanel();
+    togglePanel();
   }
 });

--- a/browser-extension/chrome-extension/src/content.js
+++ b/browser-extension/chrome-extension/src/content.js
@@ -3,17 +3,12 @@ import { getVideo, disconnectOverlayObserver, removeOverlayCanvas, createOverlay
 
 const PANEL_ID = 'yt-shot-labeler-panel';
 let detector = null;
-let poseLoopId = null;
 
 // Pose overlay loop
 async function poseOverlayLoop(video, detector, overlay) {
-  if (video.videoWidth === 0 || video.videoHeight === 0 || video.paused || video.ended) {
-    poseLoopId = requestAnimationFrame(() => poseOverlayLoop(video, detector, overlay));
-    return;
-  }
   const poses = await detector.estimatePoses(video, { maxPoses: 6 });
   drawKeypoints(overlay, poses);
-  poseLoopId = requestAnimationFrame(() => poseOverlayLoop(video, detector, overlay));
+  requestAnimationFrame(() => poseOverlayLoop(video, detector, overlay));
 }
 
 // Start overlay
@@ -30,10 +25,6 @@ async function startPoseOverlay() {
 
 // Stop overlay
 function stopPoseOverlay() {
-  if (poseLoopId) {
-    cancelAnimationFrame(poseLoopId);
-    poseLoopId = null;
-  }
   const canvas = document.getElementById('pose-overlay-canvas');
   if (canvas) {
     const ctx = canvas.getContext('2d');

--- a/browser-extension/chrome-extension/src/content.js
+++ b/browser-extension/chrome-extension/src/content.js
@@ -6,17 +6,6 @@ let detector = null;
 let overlayActive = false;
 let poseLoopId = null;
 
-// Initialize main video and overlay state
-export function init() {
-  if (overlayActive) {
-    stopPoseOverlay(); // stop overlay if active
-    startPoseOverlay(); // andre-start overlay
-  }
-}
-
-window.addEventListener('DOMContentLoaded', init); // Ensures that init runs only after HTML document is fully loaded and parsed
-document.addEventListener('yt-navigate-finish', init); // Ensures that init re-runs after navigating to new videos
-
 // Main pose overlay loop
 async function poseOverlayLoop(video, overlay) {
   if (!overlayActive) return;

--- a/browser-extension/chrome-extension/src/content.js
+++ b/browser-extension/chrome-extension/src/content.js
@@ -6,14 +6,14 @@ let detector = null;
 let poseLoopId = null;
 
 // Pose overlay loop
-async function poseOverlayLoop(video, overlay) {
+async function poseOverlayLoop(video, detector, overlay) {
   if (video.videoWidth === 0 || video.videoHeight === 0 || video.paused || video.ended) {
-    poseLoopId = requestAnimationFrame(() => poseOverlayLoop(video, overlay));
+    poseLoopId = requestAnimationFrame(() => poseOverlayLoop(video, detector, overlay));
     return;
   }
   const poses = await detector.estimatePoses(video, { maxPoses: 6 });
   drawKeypoints(overlay, poses);
-  poseLoopId = requestAnimationFrame(() => poseOverlayLoop(video, overlay));
+  poseLoopId = requestAnimationFrame(() => poseOverlayLoop(video, detector, overlay));
 }
 
 // Start overlay
@@ -25,7 +25,7 @@ async function startPoseOverlay() {
   }
   if (!detector) detector = await setupDetector();
   const overlay = createOverlayCanvas(video);
-  poseOverlayLoop(video, overlay);
+  poseOverlayLoop(video, detector, overlay);
 }
 
 // Stop overlay

--- a/browser-extension/chrome-extension/src/content.js
+++ b/browser-extension/chrome-extension/src/content.js
@@ -1,102 +1,24 @@
 window.addEventListener('DOMContentLoaded', init); // Ensures that init runs only after HTML document is fully loaded and parsed
 document.addEventListener('yt-navigate-finish', init); // Ensures that init re-runs after navigating to new videos
 
-import * as poseDetection from '@tensorflow-models/pose-detection';
-import * as tf from '@tensorflow/tfjs-core';
-import '@tensorflow/tfjs-backend-webgl';
-
 import { createLabelerPanel } from './panel.js'; 
+import { getVideo, disconnectOverlayObserver, removeOverlayCanvas, createOverlayCanvas, drawKeypoints, setupDetector } from './utils.js'; 
 
 const PANEL_ID = 'yt-shot-labeler-panel';
 let detector = null;
 let overlayActive = false;
 let poseLoopId = null;
-let mainVideo = null;
-
-// --- Helper functions ---
-// Remove overlay canvas from DOM
-function removeOverlayCanvas() {
-  const oldCanvas = document.getElementById('pose-overlay-canvas');
-  if (oldCanvas?.parentElement) oldCanvas.parentElement.removeChild(oldCanvas);
-}
-
-// Disconnect ResizeObserver for overlay
-function disconnectOverlayObserver() {
-  if (window.overlayResizeObserver) {
-    window.overlayResizeObserver.disconnect();
-    window.overlayResizeObserver = null;
-  }
-}
-
-// Get the latest YouTube video element
-function getLatestVideo() {
-  const videos = document.getElementsByClassName('html5-main-video');
-  return videos.length ? videos[videos.length - 1] : null;
-}
 
 // Initialize main video and overlay state
-function init() {
-  mainVideo = getLatestVideo();
-  if (!mainVideo) return;
+export function init() {
   if (overlayActive) stopPoseOverlay();
   // Optionally, auto-start overlay here if desired
-}
-
-// Create overlay canvas and attach to video container
-function createOverlayCanvas(video) {
-  removeOverlayCanvas();
-  disconnectOverlayObserver();
-  const containers = document.getElementsByClassName('html5-video-container');
-  const container = containers.length ? containers[containers.length - 1] : video.parentElement;
-  const canvas = document.createElement('canvas');
-  canvas.id = 'pose-overlay-canvas';
-  canvas.style.position = 'absolute';
-  canvas.style.top = '0px';
-  canvas.style.left = '0px';
-  canvas.style.pointerEvents = 'none';
-  canvas.style.zIndex = 10000;
-  canvas.width = video.videoWidth;
-  canvas.height = video.videoHeight;
-  container.appendChild(canvas);
-  window.overlayResizeObserver?.disconnect();
-  window.overlayResizeObserver = new ResizeObserver(() => {
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
-  });
-  window.overlayResizeObserver.observe(video);
-  return canvas;
-}
-
-// Draw pose keypoints on overlay canvas
-function drawKeypoints(canvas, poses, threshold = 0.2) {
-  const ctx = canvas.getContext('2d');
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  poses.forEach(pose => {
-    pose.keypoints.forEach(kp => {
-      if (kp.score > threshold) {
-        ctx.beginPath();
-        ctx.arc(kp.x, kp.y, 5, 0, 2 * Math.PI);
-        ctx.fillStyle = 'red';
-        ctx.fill();
-      }
-    });
-  });
-}
-
-// Setup pose detector
-async function setupDetector() {
-  await tf.setBackend('webgl');
-  await tf.ready();
-  detector = await poseDetection.createDetector(
-    poseDetection.SupportedModels.MoveNet,
-    { modelType: poseDetection.movenet.modelType.MULTIPOSE_LIGHTNING }
-  );
 }
 
 // Main pose overlay loop
 async function poseOverlayLoop(video, overlay) {
   if (!overlayActive) return;
-  const currentVideo = getLatestVideo();
+  const currentVideo = getVideo();
   let currentOverlay = overlay;
   if (currentVideo !== video) {
     removeOverlayCanvas();
@@ -124,12 +46,12 @@ async function poseOverlayLoop(video, overlay) {
 // Start overlay
 async function startPoseOverlay() {
   if (overlayActive) return;
-  const video = getLatestVideo();
+  const video = getVideo();
   if (!video || video.videoWidth === 0) {
     alert('No video element found or video not loaded.');
     return;
   }
-  if (!detector) await setupDetector();
+  if (!detector) detector = await setupDetector();
   const overlay = createOverlayCanvas(video);
   overlayActive = true;
   poseOverlayLoop(video, overlay);

--- a/browser-extension/chrome-extension/src/content.js
+++ b/browser-extension/chrome-extension/src/content.js
@@ -1,13 +1,14 @@
 import { togglePanel } from './panel.js';
 import { getVideo, disconnectOverlayObserver, removeOverlayCanvas, createOverlayCanvas, drawKeypoints, setupDetector } from './utils.js'; 
 
-let detector = null;
+let detector = null; // Pose detector instance (needed for pose estimation)
+let poseLoopId = null; // ID of the pose overlay loop (needed for canceling)
 
 // Pose overlay loop
 async function poseOverlayLoop(video, detector, overlay) {
   const poses = await detector.estimatePoses(video, { maxPoses: 6 });
   drawKeypoints(overlay, poses);
-  requestAnimationFrame(() => poseOverlayLoop(video, detector, overlay));
+  poseLoopId = window.requestAnimationFrame(() => poseOverlayLoop(video, detector, overlay));
 }
 
 // Start overlay
@@ -24,11 +25,11 @@ async function startPoseOverlay() {
 
 // Stop overlay
 function stopPoseOverlay() {
-  const canvas = document.getElementById('pose-overlay-canvas');
-  if (canvas) {
-    const ctx = canvas.getContext('2d');
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  if (poseLoopId) {
+    window.cancelAnimationFrame(poseLoopId);
+    poseLoopId = null;
   }
+  removeOverlayCanvas();
 }
 
 // Listen for start/stop overlay events from panel button

--- a/browser-extension/chrome-extension/src/panel.js
+++ b/browser-extension/chrome-extension/src/panel.js
@@ -1,3 +1,5 @@
+const PANEL_ID = 'yt-shot-labeler-panel';
+
 import { formatDateTime, sanitize, getVideoTitle, getVideo } from './utils.js';
 import { addResizeHandles } from './resize.js';
 import { addDragBehavior } from './drag.js';
@@ -5,7 +7,6 @@ import { setupCSV } from './csv.js';
 import { setupGlossaryButtons } from './glossary.js';
 
 export function createLabelerPanel() {
-  const PANEL_ID = 'yt-shot-labeler-panel';
   if (document.getElementById(PANEL_ID)) return;
 
   let shots = [];
@@ -174,4 +175,13 @@ export function createLabelerPanel() {
   };
 
   updateStatus();
+}
+
+export function togglePanel() {
+  const panel = document.getElementById(PANEL_ID);
+  if (panel) {
+    panel.remove();
+  } else {
+    createLabelerPanel();
+  }
 }

--- a/browser-extension/chrome-extension/src/poseDrawing.js
+++ b/browser-extension/chrome-extension/src/poseDrawing.js
@@ -1,0 +1,58 @@
+// MoveNet keypoint connections (for skeleton lines)
+const MOVENET_CONNECTIONS = [
+  [0, 1], [1, 3], [0, 2], [2, 4], // Head to shoulders
+  [5, 7], [7, 9], // Left arm
+  [6, 8], [8, 10], // Right arm
+  [5, 6], // Shoulders
+  [5, 11], [6, 12], // Torso
+  [11, 12], // Hips
+  [11, 13], [13, 15], // Left leg
+  [12, 14], [14, 16]  // Right leg
+];
+
+// Draw pose keypoints on overlay canvas
+export function drawKeypoints(canvas, poses, threshold = 0.2) {
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  poses.forEach(pose => {
+    pose.keypoints.forEach(kp => {
+      if (kp.score > threshold) {
+        ctx.beginPath();
+        ctx.arc(kp.x, kp.y, 5, 0, 2 * Math.PI);
+        ctx.fillStyle = 'red';
+        ctx.fill();
+      }
+    });
+  });
+}
+
+// Draw skeleton lines and bounding boxes
+export function drawSkeletonAndBoxes(ctx, poses, threshold = 0.2) {
+  poses.forEach(pose => {
+// Draw bounding box if available
+if (pose.box) {
+  // Use normalized coordinates (0-1) if needed, or scale to canvas size
+  const x = pose.box.xMin * ctx.canvas.width;
+  const y = pose.box.yMin * ctx.canvas.height;
+  const width = (pose.box.xMax - pose.box.xMin) * ctx.canvas.width;
+  const height = (pose.box.yMax - pose.box.yMin) * ctx.canvas.height;
+  ctx.strokeStyle = 'blue';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(x, y, width, height);
+}
+
+    // Draw skeleton lines
+    ctx.strokeStyle = 'lime';
+    ctx.lineWidth = 2;
+    MOVENET_CONNECTIONS.forEach(([i, j]) => {
+      const kp1 = pose.keypoints[i];
+      const kp2 = pose.keypoints[j];
+      if (kp1.score > threshold && kp2.score > threshold) {
+        ctx.beginPath();
+        ctx.moveTo(kp1.x, kp1.y);
+        ctx.lineTo(kp2.x, kp2.y);
+        ctx.stroke();
+      }
+    });
+  });
+}

--- a/browser-extension/chrome-extension/src/utils.js
+++ b/browser-extension/chrome-extension/src/utils.js
@@ -87,18 +87,3 @@ export async function setupDetector() {
   );
 }
 
-// Draw pose keypoints on overlay canvas
-export function drawKeypoints(canvas, poses, threshold = 0.2) {
-  const ctx = canvas.getContext('2d');
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  poses.forEach(pose => {
-    pose.keypoints.forEach(kp => {
-      if (kp.score > threshold) {
-        ctx.beginPath();
-        ctx.arc(kp.x, kp.y, 5, 0, 2 * Math.PI);
-        ctx.fillStyle = 'red';
-        ctx.fill();
-      }
-    });
-  });
-}

--- a/browser-extension/chrome-extension/src/utils.js
+++ b/browser-extension/chrome-extension/src/utils.js
@@ -1,5 +1,11 @@
+// Import Tensorflow.js
+import * as poseDetection from '@tensorflow-models/pose-detection';
+import * as tf from '@tensorflow/tfjs-core';
+import '@tensorflow/tfjs-backend-webgl';
+
 // Utility functions
 
+// For panel.js
 export function formatDateTime(dt) {
   const pad = (n) => n.toString().padStart(2, '0');
   return `${dt.getFullYear()}-${pad(dt.getMonth() + 1)}-${pad(dt.getDate())} ${pad(dt.getHours())}:${pad(dt.getMinutes())}:${pad(dt.getSeconds())}`;
@@ -24,6 +30,75 @@ export function getVideoTitle() {
   return title;
 }
 
+// Get the latest YouTube video element
 export function getVideo() {
-  return document.querySelector("video");
+  const videos = document.getElementsByClassName('html5-main-video');
+  return videos.length ? videos[videos.length - 1] : null;
+}
+
+// for content.js
+
+// Remove overlay canvas from DOM
+export function removeOverlayCanvas() {
+  const oldCanvas = document.getElementById('pose-overlay-canvas');
+  if (oldCanvas?.parentElement) oldCanvas.parentElement.removeChild(oldCanvas);
+}
+
+// Disconnect ResizeObserver for overlay
+export function disconnectOverlayObserver() {
+  if (window.overlayResizeObserver) {
+    window.overlayResizeObserver.disconnect();
+    window.overlayResizeObserver = null;
+  }
+}
+
+// Create overlay canvas and attach to video container
+export function createOverlayCanvas(video) {
+  removeOverlayCanvas();
+  disconnectOverlayObserver();
+  const containers = document.getElementsByClassName('html5-video-container');
+  const container = containers.length ? containers[containers.length - 1] : video.parentElement;
+  const canvas = document.createElement('canvas');
+  canvas.id = 'pose-overlay-canvas';
+  canvas.style.position = 'absolute';
+  canvas.style.top = '0px';
+  canvas.style.left = '0px';
+  canvas.style.pointerEvents = 'none';
+  canvas.style.zIndex = 10000;
+  canvas.width = video.videoWidth;
+  canvas.height = video.videoHeight;
+  container.appendChild(canvas);
+  window.overlayResizeObserver?.disconnect();
+  window.overlayResizeObserver = new ResizeObserver(() => {
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+  });
+  window.overlayResizeObserver.observe(video);
+  return canvas;
+}
+
+// Setup pose detector
+export async function setupDetector() {
+  await tf.setBackend('webgl');
+  await tf.ready();
+  return await poseDetection.createDetector(
+    poseDetection.SupportedModels.MoveNet,
+    { modelType: poseDetection.movenet.modelType.MULTIPOSE_LIGHTNING }
+  );
+}
+
+// Draw pose keypoints on overlay canvas
+export function drawKeypoints(canvas, poses, threshold = 0.2) {
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  poses.forEach(pose => {
+    pose.keypoints.forEach(kp => {
+      if (kp.score > threshold) {
+        ctx.beginPath();
+        ctx.arc(kp.x, kp.y, 5, 0, 2 * Math.PI);
+        ctx.fillStyle = 'red';
+        ctx.fill();
+      }
+    });
+  });
 }


### PR DESCRIPTION
This pull request introduces major improvements to the browser extension’s pose overlay functionality. The overlay now draws both pose skeletons (connecting lines between keypoints) and bounding boxes for detected persons using MoveNet. The codebase has also been refactored for modularity and maintainability.

## Key Changes:

- Feature: Added skeleton and bounding box drawing functions in poseDrawing.js
- Overlay: Overlay now visualizes keypoints, skeleton lines, and bounding boxes for each detected pose
- Refactor: Moved panel toggle logic to panel.js for better separation of concerns
- Cleanup: Removed redundant code and streamlined pose overlay loop logic
- Modularity: Utility functions for video, overlay, and detector management are now in utils.js
- Event Handling: Improved event listeners for overlay control and panel toggling
- Resource Management: Properly cancels animation frames and removes overlay canvas on stop

## How to Test:

1. Load the extension on YouTube (or just click "Update" if already loaded an older version) 
2. Open a Youtube Badminton video and activate the browser extension (usually a square gray icon with a "Y" inside) 
3. Use the panel to start/stop the pose overlay
4. Verify that keypoints, skeleton lines, and bounding boxes are drawn on the video
5. Confirm that stopping the overlay removes all drawings and cleans up resources

## Additional Notes:

- The codebase is now ready for further features and easier maintenance
- All changes have been rebased onto the latest main for a linear history
- At this version, the overlay does not scale correctly when video quality changes (the scaling sticks to the initially loaded video resolution) 